### PR TITLE
🏫  add license info & other key documents

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright Executable Books Project
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ To learn how to build `thebe-core` itself and contribute to the development of t
 ## Usage
 
 For more information on how to invoke thebe and connect to a kernel see [demo/index.html](./demo/index.html) and [demo/demo.js](./demo/demo.js).
+
+# License
+
+`thebe-core` is licensed under BSD 3 Clause Revised License - see [LICENSE](./LICENSE).
+
+# Acknowledgements
+
+`thebe-core` is an out of core refactor of the `thebe` library, containing refactored code from the original. `thebe` was developed as a part of OpenDreamKit – Horizon 2020 European Research Infrastructure project (676541). It is currently stewarded by the Executable Books Project. Additional support was provided by the U.S. Department of Education Open Textbooks Pilot Program funding for the LibreTexts project (P116T180029).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ To learn how to build `thebe-core` itself and contribute to the development of t
 
 For more information on how to invoke thebe and connect to a kernel see [demo/index.html](./demo/index.html) and [demo/demo.js](./demo/demo.js).
 
+# Code of Conduct
+
+See [this statement](https://github.com/executablebooks/meta/tree/master/docs/code-of-conduct.md) from Executable Books.
+
 # License
 
 `thebe-core` is licensed under BSD 3 Clause Revised License - see [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -36,4 +36,12 @@ For more information on how to invoke thebe and connect to a kernel see [demo/in
 
 # Acknowledgements
 
-`thebe-core` is an out of core refactor of the `thebe` library, containing refactored code from the original. `thebe` was developed as a part of OpenDreamKit – Horizon 2020 European Research Infrastructure project (676541). It is currently stewarded by the Executable Books Project. Additional support was provided by the U.S. Department of Education Open Textbooks Pilot Program funding for the LibreTexts project (P116T180029).
+`thebe-core` is an out of core refactor of the `thebe` library, containing refactored code from the original.
+
+It is currently stewarded by [the Executable Books Team](https://executablebooks.org/en/latest/team.html).
+
+**Previous funding**
+
+`thebe` was initially developed as a part of [OpenDreamKit](https://opendreamkit.org/) – Horizon 2020 European Research Infrastructure project (676541).
+
+Additional support was provided by the U.S. Department of Education Open Textbooks Pilot Program funding for the LibreTexts project (P116T180029).


### PR DESCRIPTION
Aligning `thebe-core` with `thebe` license